### PR TITLE
Switch primary LLM to Llama-3-70B instruct (cost cut)

### DIFF
--- a/config/api_config.py
+++ b/config/api_config.py
@@ -23,8 +23,14 @@ OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 # 🤖 AI MODEL CONFIGURATION
 # Using proven models from the manual system
-PRIMARY_MODEL = "anthropic/claude-3.5-sonnet"  # Primary model for AI processing
-FALLBACK_MODEL = "nousresearch/nous-hermes-2-mixtral-8x7b-dpo"  # Fallback if primary fails
+# Default (cost-efficient) primary model – can be switched back easily
+PRIMARY_MODEL = "meta-llama/llama-3-70b-instruct"  # Cheaper but similar quality to Sonnet
+
+# Keep Claude Sonnet as the immediate fallback so quality isn't lost
+FALLBACK_MODEL = "anthropic/claude-3.5-sonnet"  # High-quality safety net
+
+# Other models we might test in future (uncomment as needed)
+# ALT_MODEL_MIXTRAL = "nousresearch/nous-hermes-2-mixtral-8x7b-dpo"
 
 # 📊 API LIMITS AND SETTINGS
 API_CONFIG = {

--- a/config/automation.py
+++ b/config/automation.py
@@ -202,7 +202,7 @@ INTEGRATION_CONFIG = {
 # 🤖 AI PROCESSING CONFIGURATION
 AI_PROCESSING_CONFIG = {
     # OpenRouter API settings (same as manual system)
-    'model': 'anthropic/claude-3.5-sonnet',  # Same model as manual system
+    'model': 'meta-llama/llama-3-70b-instruct',  # Default cost-efficient model
     'api_base_url': 'https://openrouter.ai/api/v1',
     'max_tokens': 1000,
     'temperature': 0.3,

--- a/scripts/AI-Engine.py
+++ b/scripts/AI-Engine.py
@@ -337,9 +337,19 @@ Based on the article above, provide the complete JSON response:
                 output_tokens = usage.get('completion_tokens', 0)
                 total_tokens = usage.get('total_tokens', input_tokens + output_tokens)
                 
-                # Claude 3.5 Sonnet pricing via OpenRouter (approximate)
-                input_cost_per_1k = 0.003  # $3 per 1M tokens = $0.003 per 1K
-                output_cost_per_1k = 0.015  # $15 per 1M tokens = $0.015 per 1K
+                # --- Dynamic cost table so model swaps don't require code edits elsewhere ---
+                PRICE_TABLE = {
+                    "anthropic/claude-3.5-sonnet":      (0.00300, 0.01500),  # $3 / $15 per 1M
+                    "meta-llama/llama-3-70b-instruct": (0.00035, 0.00070),  # $0.35 / $0.70 per 1M
+                    "google/gemini-2-flash":            (0.00025, 0.00050),
+                    # Add new models here ➜ "vendor/model": (in_cost, out_cost)
+                }
+
+                # Fallback: default to Sonnet rates if unknown model string
+                input_cost_per_1k, output_cost_per_1k = PRICE_TABLE.get(
+                    self.model,
+                    PRICE_TABLE.get("anthropic/claude-3.5-sonnet")
+                )
                 
                 # Calculate actual cost
                 input_cost = (input_tokens / 1000) * input_cost_per_1k


### PR DESCRIPTION
This PR switches the pipeline’s primary model from Claude-Sonnet to **Llama-3-70B-Instruct**, keeps Sonnet as fallback, and adds a dynamic cost table.\n\nMerging will reduce AI cost roughly 90 %.