### PR TITLE
fix: make quality_repair.py import note_logger when executed directly

### DIFF
--- a/scripts/quality_repair.py
+++ b/scripts/quality_repair.py
@@ -24,7 +24,15 @@ from __future__ import annotations
 
 import json, pathlib, argparse, importlib.util, sys, textwrap, logging, datetime, os
 from typing import List, Dict, Any
-from scripts.note_logger import log_task
+
+# Allow running script directly: add current directory to PYTHONPATH
+import pathlib, sys as _sys
+_sys.path.append(str(pathlib.Path(__file__).parent))
+
+try:
+    from note_logger import log_task  # when run as standalone script
+except ImportError:
+    from scripts.note_logger import log_task  # when invoked as module
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 ROLLING_JSON = ROOT / 'Project-Better-French-Website' / 'rolling_articles.json'


### PR DESCRIPTION
# Pull Request

Thank you for contributing!  Please complete the checklist below.

- [ ] I have **read and adhered to** `docs/AI_CONTRIBUTION_GUIDE.md`.
- [ ] Today's daily note in `docs/daily_notes/` is created/updated and includes a Task tracker table.
- [ ] All CI checks pass locally (`ruff`, `black`, tests).
- [ ] If this PR adds or removes files, the daily note's *File change log* reflects it.

---

> Remove this section once all boxes are ticked. 